### PR TITLE
nothing earthshattering

### DIFF
--- a/software/control_sw/setup.py
+++ b/software/control_sw/setup.py
@@ -5,7 +5,7 @@ import os
 ver = '0.0.1'
 try:
     import subprocess
-    ver = ver + '-' + subprocess.check_output(['git', 'describe', '--abbrev=8', '--always', '--dirty', '--tags']).decode().strip()
+    ver = ver + '+' + subprocess.check_output(['git', 'describe', '--abbrev=8', '--always', '--dirty', '--tags']).decode().strip()
     print('Version is: %s' % ver)
 except:
     print('Couldn\'t get version from git. Defaulting to %s' % ver)

--- a/software/control_sw/src/blocks/accumulator.py
+++ b/software/control_sw/src/blocks/accumulator.py
@@ -125,7 +125,7 @@ class Accumulator(Block):
         return self._read_bram()
 
 
-    def plot_spectra(self, power=True, db=True, show=True, fftshift=True, sample_rate_hz=None):
+    def plot_spectra(self, power=True, db=True, show=True, fftshift=False, sample_rate_hz=None):
         """
         Plot the spectra of all signals in a single signal_block,
         with accumulation length divided out

--- a/software/control_sw/src/blocks/accumulator.py
+++ b/software/control_sw/src/blocks/accumulator.py
@@ -7,15 +7,8 @@ from souk_mkid_readout.error_levels import *
 
 class Accumulator(Block):
     """
-    Instantiate a control interface for an Auto-Correlation block. This
-    provides auto-correlation spectra of post-FFT data.
-
-    In order to save FPGA resourece, the auto-correlation block may use a single
-    correlation core to compute the auto-correlation of a subset of the total
-    number of ADC channels at any given time. This is the case when the
-    block is instantiated with ``n_cores > 1`` and ``use_mux=True``.
-    In this case, auto-correlation spectra are captured ``n_signals / n_cores``
-    channels at a time. 
+    Instantiate a control interface for an Accumulator Block. This
+    provides a vector accumulation of post-FFT data.
 
     :param host: CasperFpga interface for host.
     :type host: casperfpga.CasperFpga
@@ -280,15 +273,8 @@ class Accumulator(Block):
 
 class WindowedAccumulator(Accumulator):
     """
-    Instantiate a control interface for an Auto-Correlation block. This
-    provides auto-correlation spectra of post-FFT data.
-
-    In order to save FPGA resourece, the auto-correlation block may use a single
-    correlation core to compute the auto-correlation of a subset of the total
-    number of ADC channels at any given time. This is the case when the
-    block is instantiated with ``n_cores > 1`` and ``use_mux=True``.
-    In this case, auto-correlation spectra are captured ``n_signals / n_cores``
-    channels at a time. 
+    Instantiate a control interface for a Windowed Accumulator Block. This
+    block applies a window to data prior to a vector accumulation of post-FFT data.
 
     :param host: CasperFpga interface for host.
     :type host: casperfpga.CasperFpga

--- a/software/control_sw/src/blocks/autocorr.py
+++ b/software/control_sw/src/blocks/autocorr.py
@@ -179,7 +179,7 @@ class AutoCorr(Block):
         :type flush_vacc: Bool or string
 
         :param filter_ksize: If not None, apply a spectral median filter
-            with this kernel size. The kernet size should be odd.
+            with this kernel size. The kernel size should be odd.
         :type filter_ksize: int
 
         :param return_list: If True, return a list else numpy.array

--- a/software/control_sw/src/blocks/chanreorder.py
+++ b/software/control_sw/src/blocks/chanreorder.py
@@ -93,7 +93,7 @@ class ChanReorder(Block):
         `ValueError` is raised
 
         :param outmap: The outmap to which data should be mapped. I.e., if
-            `outmap[0] = 16`, then the first channel out of the reordr block
+            `outmap[0] = 16`, then the first channel out of the reorder block
             will be channel 16. 
         :type outmap: list of int
 

--- a/software/control_sw/src/blocks/mixer.py
+++ b/software/control_sw/src/blocks/mixer.py
@@ -4,7 +4,7 @@ from .block import Block
 
 class Mixer(Block):
     """
-    Instantiate a control interface for a Channel Reorder block.
+    Instantiate a control interface for a Mixer block.
 
     :param host: CasperFpga interface for host.
     :type host: casperfpga.CasperFpga

--- a/software/control_sw/test_scripts/100tone_test.py
+++ b/software/control_sw/test_scripts/100tone_test.py
@@ -27,7 +27,7 @@ def setfreqlut(r,target_frequency):
     actual_frequency=round((target_frequency - MIXFREQ) / LUT_FREQUENCY_RESOLUTION) * LUT_FREQUENCY_RESOLUTION
     r.gen_lut.set_output_freq(0,
                                actual_frequency,
-                               sample_rate_mhz=s.adc_clk_mhz,
+                               sample_rate_hz=r.adc_clk_hz,
                                amplitude=1)
     return actual_frequency+MIXFREQ
 
@@ -36,7 +36,7 @@ def setfreqcordic(r,freq_hz,cordic_id=-1):
     r.output.use_cordic()
     r.gen_cordic.set_output_freq(cordic_id,
                                   (freq_hz-MIXFREQ),
-                                  sample_rate_mhz=s.adc_clk_mhz)
+                                  sample_rate_hz=r.adc_clk_hz)
 def setfreqpsb(r,freq_hz,phase=0):
     print(f'Setting freq {freq_hz} Hz; phase {phase} rads')
     freq_hz=np.atleast_1d(freq_hz)


### PR DESCRIPTION
Made a few slight tweaks digesting the repository over the last little bit. Most are just some minor fixes to doc strings.

Another is a tweak to allow python install with newer version of setuptools by building a PEP compliant version tag.

The only one that may change behavior is in the accumulator `plot_spectra()` to default `fftshift=False`. There was wrapping of the spectra that I didn't think needed to be fftshifted.